### PR TITLE
Added Primary Key getID generation for a one-to-one mapping.

### DIFF
--- a/src/main/java/org/dbtools/gen/jpa/JPABaseRecordClassRenderer.java
+++ b/src/main/java/org/dbtools/gen/jpa/JPABaseRecordClassRenderer.java
@@ -560,6 +560,12 @@ public class JPABaseRecordClassRenderer {
         }
 
         myClass.addVariable(oneToOneVar, true);
+
+        if (field.isPrimaryKey() && !myClass.isEnum()) {
+            JavaMethod getIDMethod = new JavaMethod(Access.PUBLIC, field.getJavaTypeText(), "getID");
+            getIDMethod.setContent("return " + varName + ".getID();");
+            myClass.addMethod(getIDMethod);
+        }
     }
 
     private void generateXMLCode(final SchemaDatabase dbSchema, final StringBuilder constructorElement, final StringBuilder methodToXML, final StringBuffer dtd, final String TAB, final SchemaField field, final String constName) {


### PR DESCRIPTION
Allows the primary key to be a ONETOONE mapping.

  &lt;table name="media"&gt;
    &lt;field name="_id" jdbcDataType="BIGINT" primaryKey="true" notNull="true"/&gt;
    &lt;field name="title" jdbcDataType="VARCHAR" notNull="true"/&gt;
    &lt;field name="url" jdbcDataType="VARCHAR" notNull="true"/&gt;
  &lt;/table&gt;
  &lt;table name="audio"&gt;
    &lt;field name="_id" jdbcDataType="BIGINT" primaryKey="true" notNull="true" foreignKeyTable="media" foreignKeyField="_id" foreignKeyType="ONETOONE"/&gt;
    &lt;field name="duration" jdbcDataType="BIGINT" notNull="true" defaultValue="0"/&gt;
  &lt;/table&gt;
  &lt;table name="live_stream"&gt;
    &lt;field name="_id" jdbcDataType="BIGINT" primaryKey="true" notNull="true" foreignKeyTable="media" foreignKeyField="_id" foreignKeyType="ONETOONE"/&gt;
    &lt;field name="currently_playing_url" jdbcDataType="VARCHAR" notNull="true"/&gt;
  &lt;/table&gt;

When generated AudioBaseRecord and LiveStreamBaseRecord error with no getID() method found.
