### PR TITLE
Fixed OneToMany Mapped by for multiple foreign keys of the same type.

### DIFF
--- a/src/main/java/org/dbtools/gen/jpa/JPABaseRecordClassRenderer.java
+++ b/src/main/java/org/dbtools/gen/jpa/JPABaseRecordClassRenderer.java
@@ -727,7 +727,10 @@ public class JPABaseRecordClassRenderer {
                         myClass.addMethod(Access.PUBLIC, listType, JavaVariable.getGetterMethodName(listType, items), "return java.util.Collections.unmodifiableSet(" + items + ");");
 
                         ClassInfo mappedByClassInfo = dbSchema.getTableClassInfo(fkField.getForeignKeyTable());
-                        String mappedByVarName = JavaClass.formatToJavaVariable(mappedByClassInfo.getClassName());
+                        String mappedByVarName = fkField.getCustomVarName();
+                        if (mappedByVarName == null || mappedByVarName.isEmpty()) {
+                            mappedByVarName = JavaClass.formatToJavaVariable(mappedByClassInfo.getClassName());
+                        }
 
                         myClass.addImport("javax.persistence.FetchType");
 


### PR DESCRIPTION
When multiple one to many foreign keys of the same type are in a table, dbtools generates invalid Hibernate attributes.  This fixes it.
