### PR TITLE
Fixed findAll to be JQL compliant

### DIFF
--- a/src/main/java/org/dbtools/gen/jpa/JPAJSEBaseRecordManager.java
+++ b/src/main/java/org/dbtools/gen/jpa/JPAJSEBaseRecordManager.java
@@ -140,7 +140,7 @@ public class JPAJSEBaseRecordManager {
 
     public static void addFindAllMethod(JavaClass myClass, String recordClassName) {
         myClass.addImport("javax.persistence.Query");
-        String content = "Query q = getEntityManager().createQuery(\"SELECT o FROM \" + " + recordClassName + ".TABLE + \" o\");\n"
+        String content = "Query q = getEntityManager().createQuery(\"SELECT o FROM \" + " + recordClassName + ".TABLE_CLASSNAME + \" o\");\n"
                 + "return q.getResultList();\n";
 
         myClass.addImport("java.util.List");


### PR DESCRIPTION
Calling findAll crashes when reading from a table with a name that doesn't match the class name.
